### PR TITLE
Add `number_to_phone` function

### DIFF
--- a/lib/number.ex
+++ b/lib/number.ex
@@ -30,6 +30,7 @@ defmodule Number do
     quote do
       import Number.Currency
       import Number.Delimit
+      import Number.Phone
     end
   end
 end

--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -29,7 +29,7 @@ defmodule Number.Currency do
   * `:negative_format` - The format of the number when it is negative. Uses the 
     same formatting placeholders as the `:format` option.
 
-  Default settings for these options can be specified in the `Number`
+  Default config for these options can be specified in the `Number`
   application configuration.
 
       config :number, currency: [
@@ -80,7 +80,7 @@ defmodule Number.Currency do
   def number_to_currency(number, options \\ [])
   def number_to_currency(nil, _options), do: nil
   def number_to_currency(number, options) do
-    options = Dict.merge(settings, options)
+    options = Dict.merge(config, options)
     {number, format} = get_format(number, options)
     number = number_to_delimited(number, options)
 
@@ -94,7 +94,7 @@ defmodule Number.Currency do
   end
   defp get_format(number, options), do: {number, options[:format]}
 
-  defp settings do
+  defp config do
     defaults = [
       delimiter: ",",
       separator: ".",

--- a/lib/number/delimit.ex
+++ b/lib/number/delimit.ex
@@ -16,7 +16,7 @@ defmodule Number.Delimit do
   * `:separator` - The character to use to separate the number from the decimal
     places. Default: "."
 
-  Default settings for these options can be specified in the `Number`
+  Default config for these options can be specified in the `Number`
   application configuration.
 
       config :number, delimiter: [
@@ -55,7 +55,7 @@ defmodule Number.Delimit do
   def number_to_delimited(number, options \\ [])
   def number_to_delimited(nil, _options), do: nil
   def number_to_delimited(number, options) when is_integer(number) or is_float(number) do
-    options   = Dict.merge(settings, options)
+    options   = Dict.merge(config, options)
     prefix    = if number < 0, do: "-", else: ""
     delimited = case is_float(number) do
                   true  -> delimit_float(number, options[:delimiter], options[:separator], options[:precision])
@@ -95,7 +95,7 @@ defmodule Number.Delimit do
     |> String.to_char_list
   end
 
-  defp settings do
+  defp config do
     defaults = [
       delimiter: ",",
       separator: ".",

--- a/lib/number/macros.ex
+++ b/lib/number/macros.ex
@@ -1,0 +1,37 @@
+defmodule Number.Macros do
+  @moduledoc """
+  Macros used internally by `Number`. These may change at any time, so **do not
+  depend on them in your projects.**
+  """
+
+  @doc """
+  Determines whether a given value is blank or not. A value is considered blank
+  if it is `" "`, `""`, or `nil`.
+
+  ## Example
+
+      iex> Number.Macros.is_blank(" ")
+      true
+
+      iex> Number.Macros.is_blank("")
+      true
+
+      iex> Number.Macros.is_blank(nil)
+      true
+
+      iex> Number.Macros.is_blank("hello world")
+      false
+
+      iex> Number.Macros.is_blank(123)
+      false
+
+  This macro can also be used in guards:
+
+      def foo(bar) when is_blank(bar), do: # ...
+  """
+  defmacro is_blank(value) do
+    quote do
+      unquote(value) in [" ", "", nil]
+    end
+  end
+end

--- a/lib/number/phone.ex
+++ b/lib/number/phone.ex
@@ -1,0 +1,113 @@
+defmodule Number.Phone do
+  @moduledoc """
+  Provides functions to convert numbers into formatted phone number strings.
+  """
+
+  import Number.Macros, only: [is_blank: 1]
+
+  @doc """
+  Formats a number into a US phone number (e.g., (555) 123-9876). You can 
+  customize the format in the options list.
+
+  ## Options
+
+  * `:area_code` - Adds parentheses around the area code if `true`.
+
+  * `:delimiter` - Specifies the delimiter to use (defaults to “-”).
+
+  * `:extension` - Specifies an extension to add to the end of the generated number.
+
+  * `:country_code` - Sets the country code for the phone number.
+
+  Default config for these options can be specified in the `Number`
+  application configuration.
+
+      config :number, phone: [
+                        area_code: false,
+                        delimiter: "-",
+                        extension: nil,
+                        country_code: nil
+                      ]
+  ## Examples
+
+      iex> Number.Phone.number_to_phone(nil)
+      nil
+
+      iex> Number.Phone.number_to_phone(5551234)
+      "555-1234"
+
+      iex> Number.Phone.number_to_phone("5551234")
+      "555-1234"
+
+      iex> Number.Phone.number_to_phone(1235551234)
+      "123-555-1234"
+
+      iex> Number.Phone.number_to_phone(1235551234, area_code: true)
+      "(123) 555-1234"
+      
+      iex> Number.Phone.number_to_phone(1235551234, delimiter: " ")
+      "123 555 1234"
+
+      iex> Number.Phone.number_to_phone(1235551234, area_code: true, extension: 555)
+      "(123) 555-1234 x 555"
+
+      iex> Number.Phone.number_to_phone(1235551234, area_code: true, extension: 555, country_code: 1)
+      "+1 (123) 555-1234 x 555"
+
+      iex> Number.Phone.number_to_phone(1235551234, country_code: 1)
+      "+1-123-555-1234"
+
+      iex> Number.Phone.number_to_phone("123a456")
+      "123a456"
+
+      iex> Number.Phone.number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: ".")
+      "+1.123.555.1234 x 1343"
+  """
+  @spec number_to_phone(number, list) :: String.t
+  def number_to_phone(number, options \\ [])
+  def number_to_phone(nil, _options), do: nil
+  def number_to_phone(number, options) do
+    options = Dict.merge(config, options)
+
+    number
+    |> to_string
+    |> delimit_number(options[:delimiter], options[:area_code])
+    |> prepend_country_code(options[:country_code], options[:delimiter], options[:area_code])
+    |> append_extension(options[:extension])
+  end
+
+  defp delimit_number(number, delimiter, area_code) when area_code == false do
+    {:ok, leading_delimiter} = "^#{Regex.escape(delimiter)}" |> Regex.compile
+
+    number
+    |> String.replace(~r/(\d{0,3})(\d{3})(\d{4})$/, "\\1#{delimiter}\\2#{delimiter}\\3")
+    |> String.replace(leading_delimiter, "")
+  end
+  defp delimit_number(number, delimiter, area_code) when area_code == true do
+    String.replace(number, ~r/(\d{1,3})(\d{3})(\d{4}$)/, "(\\1) \\2#{delimiter}\\3")
+  end
+
+  defp prepend_country_code(number, country_code, _, _) when is_blank(country_code), do: number
+  defp prepend_country_code(number, country_code, delimiter, area_code) when area_code == false do
+    "+#{country_code}#{delimiter}#{number}"
+  end
+  defp prepend_country_code(number, country_code, _, area_code) when area_code == true do
+    "+#{country_code} #{number}"
+  end
+
+  defp append_extension(number, extension) when is_blank(extension), do: number
+  defp append_extension(number, extension) do
+    "#{number} x #{extension}"
+  end
+
+  defp config do
+    defaults = [
+      area_code: false,
+      delimiter: "-",
+      extension: nil,
+      country_code: nil
+    ]
+
+    Dict.merge(defaults, Application.get_env(:number, :phone, []))
+  end
+end

--- a/test/number/macros_test.exs
+++ b/test/number/macros_test.exs
@@ -1,0 +1,5 @@
+defmodule Number.MacrosTest do
+  use ExUnit.Case
+
+  doctest Number.Macros
+end

--- a/test/number/phone_test.exs
+++ b/test/number/phone_test.exs
@@ -1,0 +1,5 @@
+defmodule Number.PhoneTest do
+  use ExUnit.Case
+
+  doctest Number.Phone
+end


### PR DESCRIPTION
Provides the `number_to_phone` function from Rails in the new `Number.Phone` module. Also includes a new `Number.Macros` module for internal use.