### PR TITLE
Improve Keybase Signature Validation

### DIFF
--- a/.kbignore
+++ b/.kbignore
@@ -1,0 +1,9 @@
+test/
+script/
+config/
+mix.lock
+NOTICE
+.travis.yml
+.gitignore
+.kbignore
+CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -49,3 +49,16 @@ end
 
 See the Hex documentation for more information about the modules provided by 
 `Number`.
+
+## Signature
+
+`Number` is signed with [Keybase](https://keybase.io) to ensure authenticity.
+If you have keybase installed, you can validate the signature from the root
+directory using:
+
+```
+keybase dir verify
+```
+
+If you have installed `Number` as a hex package, simply `cd` to `deps/number`
+and run the above command in that directory.

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Currency.Mixfile do
 
   defp package do
     [
-      files: ["lib", "mix.exs", "README.md", "LICENSE"],
+      files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "SIGNED.md", "LICENSE"],
       contributors: ["Daniel Berkompas"],
       licenses: ["MIT"],
       links: %{


### PR DESCRIPTION
These changes ensure that the keybase signature can be validated when `Number` is downloaded as a hex package.