### PR TITLE
Fix number_to_human rounding and skipping errors

### DIFF
--- a/lib/number/delimit.ex
+++ b/lib/number/delimit.ex
@@ -37,6 +37,9 @@ defmodule Number.Delimit do
       iex> Number.Delimit.number_to_delimited(nil)
       nil
 
+      iex> Number.Delimit.number_to_delimited(998.999)
+      "999.00"
+
       iex> Number.Delimit.number_to_delimited(-234234.234)
       "-234,234.23"
 
@@ -89,6 +92,7 @@ defmodule Number.Delimit do
   end
 
   defp delimit_float(number, delimiter, separator, precision) do
+    number = Float.round(number, precision)
     decimals = isolate_decimals(number, precision)
     integer = number |> trunc |> delimit_integer(delimiter)
     separator = if precision == 0, do: '', else: separator

--- a/lib/number/human.ex
+++ b/lib/number/human.ex
@@ -5,8 +5,8 @@ defmodule Number.Human do
 
   import Number.Delimit, only: [number_to_delimited: 2]
   import Number.Macros, only: [number_between: 3]
-  
-  @increments [ 
+
+  @increments [
     {"Thousand", 1_000},
     {"Million",  1_000_000},
     {"Billion",  1_000_000_000},
@@ -27,8 +27,8 @@ defmodule Number.Human do
       iex> Number.Human.number_to_human(1234)
       "1.23 Thousand"
 
-      iex> Number.Human.number_to_human(12345)
-      "12.35 Thousand"
+      iex> Number.Human.number_to_human(999001)
+      "999.00 Thousand"
 
       iex> Number.Human.number_to_human(1234567)
       "1.23 Million"
@@ -53,9 +53,9 @@ defmodule Number.Human do
     to_string(number)
   end
   for {label, min} = increment <- @increments do
-    max = if increment == @last, do: false, else: min * 999
+    max = if increment == @last, do: false, else: min * 999.999
 
-    def number_to_human(number, options) 
+    def number_to_human(number, options)
     when number_between(number, unquote(min), unquote(max)) do
       number = number_to_delimited(number / unquote(min), options)
       number <> " " <> unquote(label)


### PR DESCRIPTION
As reported in #10, `number_to_human` does not properly handle numbers
such as 999,001 or 999,999, and it also incorrectly rounds 998.99 to
998.00.

This commit fixes both issues. Contrary to what the bug report
suggested, 998.999 should round to 999.00 with a precision of 2, not
998.99.

Closes #10.