### PR TITLE
[#18] Improve precision using Decimal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.2.0
+  - 1.3.0
 otp_release:
   - 18.1
 before_script:

--- a/lib/number/conversion.ex
+++ b/lib/number/conversion.ex
@@ -3,6 +3,9 @@ defprotocol Number.Conversion do
 
   @doc "Converts a value to a Float."
   def to_float(value)
+
+  @doc "Converts a value to a Decimal."
+  def to_decimal(value)
 end
 
 defimpl Number.Conversion, for: BitString do
@@ -12,14 +15,27 @@ defimpl Number.Conversion, for: BitString do
       :error     -> raise ArgumentError, "could not convert #{inspect value} to float"
     end
   end
+
+  def to_decimal(value) do
+    string = String.Chars.to_string(value)
+    Decimal.new(value)
+  end
 end
 
 defimpl Number.Conversion, for: Float do
   def to_float(value), do: value
+
+  def to_decimal(value) do
+    Decimal.new(value)
+  end
 end
 
 defimpl Number.Conversion, for: Integer do
   def to_float(value), do: value * 1.0
+
+  def to_decimal(value) do
+    Decimal.new(value)
+  end
 end
 
 if Code.ensure_loaded?(Decimal) do
@@ -30,6 +46,10 @@ if Code.ensure_loaded?(Decimal) do
         |> Decimal.to_string
         |> Float.parse
       float
+    end
+
+    def to_decimal(value) do
+      value
     end
   end
 end

--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -54,13 +54,13 @@ defmodule Number.Currency do
       nil
 
       iex> Number.Currency.number_to_currency(1000)
-      "$1,000"
+      "$1,000.00"
 
       iex> Number.Currency.number_to_currency(1000, unit: "£")
-      "£1,000"
+      "£1,000.00"
 
       iex> Number.Currency.number_to_currency(-1000)
-      "-$1,000"
+      "-$1,000.00"
 
       iex> Number.Currency.number_to_currency(-234234.23)
       "-$234,234.23"

--- a/lib/number/delimit.ex
+++ b/lib/number/delimit.ex
@@ -44,16 +44,16 @@ defmodule Number.Delimit do
       "-234,234.23"
 
       iex> Number.Delimit.number_to_delimited(12345678)
-      "12,345,678"
+      "12,345,678.00"
 
       iex> Number.Delimit.number_to_delimited(12345678.05)
       "12,345,678.05"
 
       iex> Number.Delimit.number_to_delimited(12345678, delimiter: ".")
-      "12.345.678"
+      "12.345.678.00"
 
       iex> Number.Delimit.number_to_delimited(12345678, delimiter: ",")
-      "12,345,678"
+      "12,345,678.00"
 
       iex> Number.Delimit.number_to_delimited(12345678.05, separator: " ")
       "12,345,678 05"
@@ -63,6 +63,12 @@ defmodule Number.Delimit do
 
       iex> Number.Delimit.number_to_delimited(Decimal.new(9998.2))
       "9,998.20"
+
+      iex> Number.Delimit.number_to_delimited "123456789555555555555555555555555"
+      "123,456,789,555,555,555,555,555,555,555,555.00"
+
+      iex> Number.Delimit.number_to_delimited Decimal.new("123456789555555555555555555555555")
+      "123,456,789,555,555,555,555,555,555,555,555.00"
   """
   @spec number_to_delimited(number, list) :: String.t
   def number_to_delimited(number, options \\ [])
@@ -71,17 +77,48 @@ defmodule Number.Delimit do
     options   = Dict.merge(config, options)
     prefix    = if number < 0, do: "-", else: ""
     delimited =
-      case is_integer(number) do
-        true ->
-          delimit_integer(number, options[:delimiter])
-        false ->
-          number
-          |> Number.Conversion.to_float
-          |> delimit_float(options[:delimiter], options[:separator], options[:precision])
+      case to_integer(number) do
+        {:ok, number} ->
+          number = delimit_integer(number, options[:delimiter])
+
+          if options[:precision] > 0 do
+            decimals = String.pad_trailing("", options[:precision], "0")
+            Enum.join([to_string(number), options[:separator], decimals])
+          else
+            number
+          end
+        {:error, other} ->
+          other
+          |> to_string
+          |> Number.Conversion.to_decimal
+          |> delimit_decimal(options[:delimiter], options[:separator], options[:precision])
       end
 
     delimited = String.Chars.to_string(delimited)
     prefix <> delimited
+  end
+
+  defp to_integer(integer) when is_integer(integer) do
+    {:ok, integer}
+  end
+  defp to_integer(%{__struct__: Decimal} = decimal) do
+    try do
+      {:ok, Decimal.to_integer(decimal)}
+    rescue
+      _ ->
+        {:error, decimal}
+    end
+  end
+  defp to_integer(string) when is_binary(string) do
+    try do
+      {:ok, String.to_integer(string)}
+    rescue
+      _ ->
+        {:error, string}
+    end
+  end
+  defp to_integer(other) do
+    {:error, other}
   end
 
   defp delimit_integer(number, delimiter) do
@@ -97,21 +134,27 @@ defmodule Number.Delimit do
     :lists.reverse(list) ++ acc
   end
 
-  defp delimit_float(number, delimiter, separator, precision) do
-    number = Float.round(number, precision)
-    decimals = isolate_decimals(number, precision)
-    integer = number |> trunc |> delimit_integer(delimiter)
-    separator = if precision == 0, do: '', else: separator
-    :lists.flatten([integer, separator, decimals])
-  end
+  def delimit_decimal(decimal, delimiter, separator, precision) do
+    string =
+      decimal
+      |> Decimal.round(precision)
+      |> Decimal.to_string(:normal)
 
-  defp isolate_decimals(_number, precision) when precision == 0, do: ''
-  defp isolate_decimals(number, precision) do
-    [decimals] = :io_lib.format("~.*f", [precision, number - trunc(number)])
-    decimals
-    |> String.Chars.to_string
-    |> String.replace(~r/^.*\./, "")
-    |> String.to_char_list
+    [number, decimals] =
+      case String.split(string, ".") do
+        [number, decimals] -> [number, decimals]
+        [number] -> [number, ""]
+      end
+
+    decimals = String.pad_trailing(decimals, precision, "0")
+
+    integer =
+      number
+      |> String.to_integer
+      |> delimit_integer(delimiter)
+
+    separator = if precision == 0, do: "", else: separator
+    Enum.join([integer, separator, decimals])
   end
 
   defp config do

--- a/lib/number/percentage.ex
+++ b/lib/number/percentage.ex
@@ -4,7 +4,6 @@ defmodule Number.Percentage do
   """
 
   import Number.Delimit, only: [number_to_delimited: 2]
-  import Number.Conversion, only: [to_float: 1]
 
   @doc """
   Formats a number into a percentage string.
@@ -60,11 +59,7 @@ defmodule Number.Percentage do
   def number_to_percentage(number, options \\ [])
   def number_to_percentage(number, options) do
     options = Dict.merge(config, options)
-
-    number = number
-             |> to_float
-             |> number_to_delimited(options)
-
+    number = number_to_delimited(number, options)
     number <> "%"
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Currency.Mixfile do
+defmodule Number.Mixfile do
   use Mix.Project
 
   def project do
@@ -19,7 +19,7 @@ defmodule Currency.Mixfile do
 
   defp deps do
     [
-      {:decimal, "~> 1.0", optional: true},
+      {:decimal, "~> 1.0"},
       {:ex_doc, "~> 0.11", only: :docs},
       {:inch_ex, "~> 0.3", only: :docs}
     ]


### PR DESCRIPTION
Uses Decimal everywhere possible to increase precision. Unfortunately,
this is currently not possible for `Number.SI`, since it relies on
the Erlang functions `math:log` and `math:pow` which only take floats,
and have no equivalents in the Decimal library.

See #18 for more details.