### PR TITLE
[#32] Switch to `extra_applications`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Number.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
This way, all the applications in the dependencies list will
automatically be included in builds.

Closes #32.