### PR TITLE
Use Number.t to fix type specs

### DIFF
--- a/lib/number.ex
+++ b/lib/number.ex
@@ -25,6 +25,8 @@ defmodule Number do
   contains documentation on how to configure it.
   """
 
+  @type t :: number | Decimal.t
+
   @doc false
   defmacro __using__(_) do
     quote do

--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -89,7 +89,7 @@ defmodule Number.Currency do
       iex> Number.Currency.number_to_currency(Decimal.new(-100.01))
       "-$100.01"
   """
-  @spec number_to_currency(number, list) :: String.t
+  @spec number_to_currency(Number.t, list) :: String.t
   def number_to_currency(number, options \\ [])
   def number_to_currency(nil, _options), do: nil
   def number_to_currency(number, options) do

--- a/lib/number/delimit.ex
+++ b/lib/number/delimit.ex
@@ -76,7 +76,7 @@ defmodule Number.Delimit do
       iex> Number.Delimit.number_to_delimited Decimal.new("123456789555555555555555555555555")
       "123,456,789,555,555,555,555,555,555,555,555.00"
   """
-  @spec number_to_delimited(number, list) :: String.t
+  @spec number_to_delimited(Number.t, list) :: String.t
   def number_to_delimited(number, options \\ [])
   def number_to_delimited(nil, _options), do: nil
   def number_to_delimited(number, options) do


### PR DESCRIPTION
This introduces a `Number.t` type that is `number | Decimal.t`, and fixes some inaccurate typespecs using that type. This fixes issues such as https://github.com/danielberkompas/number/issues/34.