### PR TITLE
Decimal to currency fix

### DIFF
--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -88,6 +88,9 @@ defmodule Number.Currency do
 
       iex> Number.Currency.number_to_currency(Decimal.new(-100.01))
       "-$100.01"
+
+      iex> Number.Currency.number_to_currency(Decimal.new(-100.01), unit: "$", separator: ",", delimiter: ".", negative_format: "- %u %n")
+      "- $ 100,01"
   """
   @spec number_to_currency(Number.t, list) :: String.t
   def number_to_currency(number, options \\ [])
@@ -107,10 +110,9 @@ defmodule Number.Currency do
 
     number = Decimal.new(number)
 
-    if number < 0 do
-      {Decimal.abs(number), options[:negative_format] || "-#{options[:format]}"}
-    else
-      {number, options[:format]}
+    case Decimal.cmp(number, Decimal.new(0)) do
+      :lt -> {Decimal.abs(number), options[:negative_format] || "-#{options[:format]}"}
+      _ ->{number, options[:format]}
     end
   end
 


### PR DESCRIPTION
In the current version (v5.5) if you pass a Decimal struct to `Number.Currency.number_to_currency` it ignores the negative formatting, which this PR should fix.