### PR TITLE
Drop DecimalArithmetic

### DIFF
--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -107,8 +107,6 @@ defmodule Number.Currency do
   end
 
   defp get_format(number, options) do
-    use DecimalArithmetic
-
     number = Decimal.new(number)
 
     case Decimal.cmp(number, Decimal.new(0)) do

--- a/mix.exs
+++ b/mix.exs
@@ -29,8 +29,7 @@ defmodule Number.Mixfile do
 
   defp deps do
     [
-      {:decimal, "~> 1.0"},
-      {:decimal_arithmetic, "~> 0.1"},
+      {:decimal, "~> 1.2"},
       {:excoveralls, ">= 0.0.0", only: :test},
       {:ex_doc, ">= 0.0.0", only: [:dev, :test]},
       {:inch_ex, ">= 0.0.0", only: [:dev, :test]}


### PR DESCRIPTION
It wasn't actually used anywhere.

Also fix requirement in decimal - Decimal.cmp was introduced in 1.2