### PR TITLE
Fix deprecation warnings from decimal module

### DIFF
--- a/lib/number/conversion.ex
+++ b/lib/number/conversion.ex
@@ -31,7 +31,7 @@ defimpl Number.Conversion, for: Float do
   def to_float(value), do: value
 
   def to_decimal(value) do
-    Decimal.new(value)
+    Decimal.from_float(value)
   end
 end
 

--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -83,13 +83,13 @@ defmodule Number.Currency do
       iex> Number.Currency.number_to_currency(1234567890.50, unit: "R$", separator: ",", delimiter: "", format: "%n %u")
       "1234567890,50 R$"
 
-      iex> Number.Currency.number_to_currency(Decimal.new(50.0))
+      iex> Number.Currency.number_to_currency(Decimal.from_float(50.0))
       "$50.00"
 
-      iex> Number.Currency.number_to_currency(Decimal.new(-100.01))
+      iex> Number.Currency.number_to_currency(Decimal.from_float(-100.01))
       "-$100.01"
 
-      iex> Number.Currency.number_to_currency(Decimal.new(-100.01), unit: "$", separator: ",", delimiter: ".", negative_format: "- %u %n")
+      iex> Number.Currency.number_to_currency(Decimal.from_float(-100.01), unit: "$", separator: ",", delimiter: ".", negative_format: "- %u %n")
       "- $ 100,01"
   """
   @spec number_to_currency(Number.t(), list) :: String.t()
@@ -107,7 +107,7 @@ defmodule Number.Currency do
   end
 
   defp get_format(number, options) do
-    number = Decimal.new(number)
+    number = if is_float(number), do: Decimal.from_float(number), else: Decimal.new(number)
 
     case Decimal.cmp(number, Decimal.new(0)) do
       :lt -> {Decimal.abs(number), options[:negative_format] || "-#{options[:format]}"}

--- a/lib/number/delimit.ex
+++ b/lib/number/delimit.ex
@@ -67,7 +67,7 @@ defmodule Number.Delimit do
       iex> Number.Delimit.number_to_delimited(98765432.98, delimiter: " ", separator: ",")
       "98 765 432,98"
 
-      iex> Number.Delimit.number_to_delimited(Decimal.new(9998.2))
+      iex> Number.Delimit.number_to_delimited(Decimal.from_float(9998.2))
       "9,998.20"
 
       iex> Number.Delimit.number_to_delimited "123456789555555555555555555555555"

--- a/lib/number/percentage.ex
+++ b/lib/number/percentage.ex
@@ -52,7 +52,7 @@ defmodule Number.Percentage do
       iex> Number.Percentage.number_to_percentage(302.24398923423, precision: 5)
       "302.24399%"
 
-      iex> Number.Percentage.number_to_percentage(Decimal.new(59.236), precision: 2)
+      iex> Number.Percentage.number_to_percentage(Decimal.from_float(59.236), precision: 2)
       "59.24%"
   """
   @spec number_to_percentage(number, Keyword.t()) :: String.t()

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Number.Mixfile do
 
   defp deps do
     [
-      {:decimal, "~> 1.2"},
+      {:decimal, "~> 1.5"},
       {:excoveralls, ">= 0.0.0", only: :test},
       {:ex_doc, ">= 0.0.0", only: [:dev, :test]},
       {:inch_ex, ">= 0.0.0", only: [:dev, :test]}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.6.0", "bfd84d90ff966e1f5d4370bdd3943432d8f65f07d3bab48001aebd7030590dcc", [:mix], [], "hexpm"},
   "decimal_arithmetic": {:hex, :decimal_arithmetic, "0.1.2", "26c9ddf5f06a5f9c6524dcc165f5829b80faa2bb0184747409086f21d7fd735b", [:mix], [{:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},

--- a/test/number/conversion_test.exs
+++ b/test/number/conversion_test.exs
@@ -30,11 +30,11 @@ defmodule Number.ConversionTest do
 
   describe ".to_decimal/2" do
     test "converts float to decimal" do
-      assert to_decimal(123.45) == Decimal.new(123.45)
+      assert to_decimal(123.45) == Decimal.from_float(123.45)
     end
 
     test "leaves decimal alone" do
-      assert to_decimal(Decimal.new(123.45)) == Decimal.new(123.45)
+      assert to_decimal(Decimal.from_float(123.45)) == Decimal.from_float(123.45)
     end
   end
 end


### PR DESCRIPTION
`Decimal.new/1` is deprecated for `float` in v1.6
see https://github.com/ericmj/decimal/blob/master/CHANGELOG.md#deprecations
