### PR TITLE
Update `number_to_phone/2` typespec

### DIFF
--- a/lib/number/phone.ex
+++ b/lib/number/phone.ex
@@ -72,7 +72,7 @@ defmodule Number.Phone do
       iex> Number.Phone.number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: ".")
       "+1.123.555.1234 x 1343"
   """
-  @spec number_to_phone(number, list) :: String.t()
+  @spec number_to_phone(number | String.t, list) :: String.t()
   def number_to_phone(number, options \\ [])
   def number_to_phone(nil, _options), do: nil
 


### PR DESCRIPTION
The type spec indicated the function only took a `number` but it also accepts a string. This is expressed in the documentation and tested. This commit just updates the spec to reflect that.