### PR TITLE
Update typespec for Number.Phone.number_to_phone

### DIFF
--- a/lib/number/phone.ex
+++ b/lib/number/phone.ex
@@ -72,7 +72,7 @@ defmodule Number.Phone do
       iex> Number.Phone.number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: ".")
       "+1.123.555.1234 x 1343"
   """
-  @spec number_to_phone(number, list) :: String.t()
+  @spec number_to_phone(number | String.t(), list) :: String.t()
   def number_to_phone(number, options \\ [])
   def number_to_phone(nil, _options), do: nil
 


### PR DESCRIPTION
According to the docs, this function can take a number or a string as the first argument, but the typespec specifies that it must take a number.

This updates the typspec to be in accordance with the docs and the functionality of the code.