### PR TITLE
Fix percentage spec

### DIFF
--- a/lib/number/percentage.ex
+++ b/lib/number/percentage.ex
@@ -56,7 +56,7 @@ defmodule Number.Percentage do
       iex> Number.Percentage.number_to_percentage(Decimal.from_float(59.236), precision: 2)
       "59.24%"
   """
-  @spec number_to_percentage(number, Keyword.t()) :: String.t()
+  @spec number_to_percentage(Number.t(), Keyword.t()) :: String.t()
   def number_to_percentage(number, options \\ [])
 
   def number_to_percentage(number, options) do


### PR DESCRIPTION
The typespec for `number_to_percentage/2` indicates the first argument should be `number()`. However, this argument is passed to `number_to_delimited/2`, which accepts `Number.t()`.