### PR TITLE
:label: Use `Number.t` and `Keyword.t` in typespecs

### DIFF
--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -94,7 +94,7 @@ defmodule Number.Currency do
       "- $ 100,01"
 
   """
-  @spec number_to_currency(Number.t(), list) :: String.t()
+  @spec number_to_currency(Number.t(), Keyword.t()) :: String.t()
   def number_to_currency(number, options \\ [])
   def number_to_currency(nil, _options), do: nil
 

--- a/lib/number/decimal.ex
+++ b/lib/number/decimal.ex
@@ -7,6 +7,7 @@ defmodule Number.Decimal do
   # In Decimal >=2.0, Decimal.compare/2 returns :lt, :gt, :eq.
   #
   # See https://github.com/danielberkompas/number/issues/47
+  @spec compare(Decimal.t(), Decimal.t()) :: :lt | :gt | :eq
   def compare(a, b) do
     result = Decimal.compare(a, b)
 

--- a/lib/number/delimit.ex
+++ b/lib/number/delimit.ex
@@ -77,8 +77,8 @@ defmodule Number.Delimit do
       iex> Number.Delimit.number_to_delimited Decimal.new("123456789555555555555555555555555")
       "123,456,789,555,555,555,555,555,555,555,555.00"
   """
-  @spec number_to_delimited(nil, list) :: nil
-  @spec number_to_delimited(Number.t(), list) :: String.t()
+  @spec number_to_delimited(nil, Keyword.t()) :: nil
+  @spec number_to_delimited(Number.t() | String.t(), Keyword.t()) :: String.t()
   def number_to_delimited(number, options \\ [])
   def number_to_delimited(nil, _options), do: nil
 

--- a/lib/number/human.ex
+++ b/lib/number/human.ex
@@ -42,6 +42,7 @@ defmodule Number.Human do
       ** (ArgumentError) number must be a float, integer or implement `Number.Conversion` protocol, was 'charlist'
 
   """
+  @spec number_to_human(Number.t(), Keyword.t()) :: String.t()
   def number_to_human(number, options \\ [])
 
   def number_to_human(number, options) when not is_map(number) do
@@ -99,6 +100,7 @@ defmodule Number.Human do
       "4001st"
 
   """
+  @spec number_to_ordinal(Number.t()) :: String.t()
   def number_to_ordinal(number) when is_integer(number) do
     sfx = ~w(th st nd rd th th th th th th)
 

--- a/lib/number/phone.ex
+++ b/lib/number/phone.ex
@@ -72,7 +72,7 @@ defmodule Number.Phone do
       iex> Number.Phone.number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: ".")
       "+1.123.555.1234 x 1343"
   """
-  @spec number_to_phone(number | String.t(), list) :: String.t()
+  @spec number_to_phone(Number.t() | String.t(), Keyword.t()) :: String.t()
   def number_to_phone(number, options \\ [])
   def number_to_phone(nil, _options), do: nil
 

--- a/lib/number/si.ex
+++ b/lib/number/si.ex
@@ -96,7 +96,7 @@ defmodule Number.SI do
       iex> Number.SI.number_to_si('charlist')
       ** (ArgumentError) number must be a float, integer or implement `Number.Conversion` protocol, was 'charlist'
   """
-  @spec number_to_si(number, list) :: String.t()
+  @spec number_to_si(Number.t(), Keyword.t()) :: String.t()
   def number_to_si(number, options \\ [])
 
   def number_to_si(number, options) when is_number(number) do


### PR DESCRIPTION
These typespecs were not consistent everywhere.
