### PR TITLE
:recycle: Replace `Mix.Config` with `Config`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,4 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this


### PR DESCRIPTION
Fixes a deprecation warning when developing `number` on Elixir 1.14. Should have no production impact though.
