### PR TITLE
add nil as potential return value

### DIFF
--- a/lib/number/currency.ex
+++ b/lib/number/currency.ex
@@ -94,7 +94,7 @@ defmodule Number.Currency do
       "- $ 100,01"
 
   """
-  @spec number_to_currency(Number.t(), Keyword.t()) :: String.t()
+  @spec number_to_currency(Number.t(), Keyword.t()) :: String.t() | nil
   def number_to_currency(number, options \\ [])
   def number_to_currency(nil, _options), do: nil
 


### PR DESCRIPTION
Noticed a type error on one of my repos when pattern matching a nil response. `number_to_currency` has a definition that returns nil, and there is also an example of such.